### PR TITLE
feat : 사용자 정보 조회 기능 구현

### DIFF
--- a/src/main/java/louie/hanse/shareplate/service/MemberService.java
+++ b/src/main/java/louie/hanse/shareplate/service/MemberService.java
@@ -5,6 +5,7 @@ import louie.hanse.shareplate.domain.Member;
 import louie.hanse.shareplate.repository.MemberRepository;
 import louie.hanse.shareplate.web.dto.member.MemberChangeLocationRequest;
 import louie.hanse.shareplate.web.dto.member.MemberChangeUserInfoRequest;
+import louie.hanse.shareplate.web.dto.member.MemberUserInfoResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,8 +19,7 @@ public class MemberService {
     @Transactional
     public void changeLocation(MemberChangeLocationRequest request, Long id) {
 //        TODO 커스텀 Exception
-        Member member = memberRepository.findById(id)
-            .orElseThrow();
+        Member member = findMember(id);
         member.changeLocation(request.getLocation());
         member.changeLongitude(request.getLongitude());
         member.changeLatitude(request.getLatitude());
@@ -28,10 +28,18 @@ public class MemberService {
     @Transactional
     public void changeUserInfo(MemberChangeUserInfoRequest request, Long id) {
         //        TODO 커스텀 Exception
-        Member member = memberRepository.findById(id)
-            .orElseThrow();
+        Member member = findMember(id);
         member.changeProfileImageUrl(request.getProfileImageUrl());
         member.changeNickname(request.getNickname());
-        member.changeEmail(request.getEmail());
+    }
+
+    public MemberUserInfoResponse getUserInfo(Long id) {
+        //        TODO 커스텀 Exception
+        Member member = findMember(id);
+        return new MemberUserInfoResponse(member);
+    }
+
+    private Member findMember(Long id) {
+        return memberRepository.findById(id).orElseThrow();
     }
 }

--- a/src/main/java/louie/hanse/shareplate/web/controller/MemberController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/MemberController.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import louie.hanse.shareplate.service.MemberService;
 import louie.hanse.shareplate.web.dto.member.MemberChangeLocationRequest;
 import louie.hanse.shareplate.web.dto.member.MemberChangeUserInfoRequest;
+import louie.hanse.shareplate.web.dto.member.MemberUserInfoResponse;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,12 @@ import javax.servlet.http.HttpServletRequest;
 public class MemberController {
 
     private final MemberService memberService;
+
+    @GetMapping
+    public MemberUserInfoResponse getUserInfo(HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        return memberService.getUserInfo(memberId);
+    }
 
     @PatchMapping
     public void changeUserInfo(@RequestBody MemberChangeUserInfoRequest memberChangeUserInfoRequest,

--- a/src/main/java/louie/hanse/shareplate/web/dto/member/MemberChangeUserInfoRequest.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/member/MemberChangeUserInfoRequest.java
@@ -7,5 +7,4 @@ public class MemberChangeUserInfoRequest {
 
     private String profileImageUrl;
     private String nickname;
-    private String email;
 }

--- a/src/main/java/louie/hanse/shareplate/web/dto/member/MemberUserInfoResponse.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/member/MemberUserInfoResponse.java
@@ -1,0 +1,17 @@
+package louie.hanse.shareplate.web.dto.member;
+
+import lombok.Getter;
+import louie.hanse.shareplate.domain.Member;
+
+@Getter
+public class MemberUserInfoResponse {
+    private String profileImageUrl;
+    private String nickname;
+    private String email;
+
+    public MemberUserInfoResponse(Member member) {
+        this.profileImageUrl = member.getProfileImageUrl();
+        this.nickname = member.getNickname();
+        this.email = member.getEmail();
+    }
+}

--- a/src/test/java/louie/hanse/shareplate/integration/MemberIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/MemberIntegrationTest.java
@@ -1,6 +1,7 @@
 package louie.hanse.shareplate.integration;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONNECTION;
 import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
@@ -58,6 +59,26 @@ class MemberIntegrationTest {
     }
 
     @Test
+    void 특정_회원의_정보를_조회한다() {
+        String accessToken = jwtProvider.createAccessToken(2355841047L);
+
+        given(documentationSpec)
+            .filter(document("member-get-information"))
+            .contentType(ContentType.JSON)
+            .header(AUTHORIZATION, accessToken)
+
+            .when()
+            .get("/members")
+
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("profileImageUrl", equalTo(
+                "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg"))
+            .body("nickname", equalTo("한승연"))
+            .body("email", equalTo("x_x_x@hanmail.net"));
+    }
+
+    @Test
     void 특정_회원의_주소를_변경한다() {
         String accessToken = jwtProvider.createAccessToken(2363364736L);
 
@@ -67,7 +88,7 @@ class MemberIntegrationTest {
         requestParams.put("latitude", 37.6576769);
 
         given(documentationSpec)
-            .filter(document("change-location"))
+            .filter(document("member-changed-location"))
             .contentType(ContentType.JSON)
             .header(AUTHORIZATION, accessToken)
             .body(requestParams)
@@ -89,7 +110,7 @@ class MemberIntegrationTest {
         requestParams.put("email", "email_test.com");
 
         given(documentationSpec)
-            .filter(document("change-user-info"))
+            .filter(document("member-changed-user-information"))
             .contentType(ContentType.JSON)
             .header(AUTHORIZATION, accessToken)
             .body(requestParams)

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,4 +1,5 @@
 INSERT INTO members
     (id, email, nickname, profile_image_url, thumbnail_image_url, latitude, longitude)
 VALUES
-    (2363364736, 'oys102809@gmail.com', '정현석', 'http://k.kakaocdn.net/dn/Zdpi8/btrGgJKuvQW/XckLpycXe5zC7iUwEhFilk/img_640x640.jpg', 'http://k.kakaocdn.net/dn/Zdpi8/btrGgJKuvQW/XckLpycXe5zC7iUwEhFilk/img_110x110.jpg', 0, 0);
+    (2363364736, 'oys102809@gmail.com', '정현석', 'http://k.kakaocdn.net/dn/Zdpi8/btrGgJKuvQW/XckLpycXe5zC7iUwEhFilk/img_640x640.jpg', 'http://k.kakaocdn.net/dn/Zdpi8/btrGgJKuvQW/XckLpycXe5zC7iUwEhFilk/img_110x110.jpg', 0, 0),
+    (2355841047, 'x_x_x@hanmail.net', '한승연', 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg', 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_110x110.jpg', 0, 0);


### PR DESCRIPTION
## ➡️ Request

### Header

Authorization : `AccessToken`

GET `/members`

### Body

```json
{}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{
	"profileImageUrl": "https:s3.asdawdwa",
	"nickname": "Louie-03",
	"email": "eadwwadwa124@gmail.com"
}
```

-------------
- 사용자 정보 조회(프로필이미지, 닉네임, 이메일)
- 테스트 코드 작성
- data.sql에서 조회용 데이터 추가
- MemberService에서 findMember 메서드 생성
- MemberChangeUserInfoRequest에서 이메일 제외