### PR TITLE
Access Token 재발급 기능 구현

### DIFF
--- a/src/main/java/louie/hanse/shareplate/config/WebConfig.java
+++ b/src/main/java/louie/hanse/shareplate/config/WebConfig.java
@@ -3,8 +3,10 @@ package louie.hanse.shareplate.config;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.converter.StringToShareTypeConverter;
+import louie.hanse.shareplate.interceptor.LogoutInterceptor;
 import louie.hanse.shareplate.interceptor.MemberVerificationInterceptor;
 import louie.hanse.shareplate.jwt.JwtProvider;
+import louie.hanse.shareplate.service.LoginService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
@@ -16,12 +18,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final JwtProvider jwtProvider;
+    private final LoginService loginService;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new MemberVerificationInterceptor(jwtProvider))
-                .order(1)
-                .addPathPatterns("/members", "/members/location", "/shares");
+            .order(1)
+            .addPathPatterns("/members", "/members/location", "/shares");
+
+        registry.addInterceptor(new LogoutInterceptor(jwtProvider, loginService))
+            .order(2)
+            .addPathPatterns("/logout", "/reissue/access-token");
     }
 
     @Override

--- a/src/main/java/louie/hanse/shareplate/config/WebConfig.java
+++ b/src/main/java/louie/hanse/shareplate/config/WebConfig.java
@@ -3,7 +3,7 @@ package louie.hanse.shareplate.config;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.converter.StringToShareTypeConverter;
-import louie.hanse.shareplate.interceptor.LoginInterceptor;
+import louie.hanse.shareplate.interceptor.MemberVerificationInterceptor;
 import louie.hanse.shareplate.jwt.JwtProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
@@ -19,7 +19,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new LoginInterceptor(jwtProvider))
+        registry.addInterceptor(new MemberVerificationInterceptor(jwtProvider))
                 .order(1)
                 .addPathPatterns("/members", "/members/location", "/shares");
     }

--- a/src/main/java/louie/hanse/shareplate/interceptor/LogoutInterceptor.java
+++ b/src/main/java/louie/hanse/shareplate/interceptor/LogoutInterceptor.java
@@ -1,0 +1,63 @@
+package louie.hanse.shareplate.interceptor;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import louie.hanse.shareplate.jwt.JwtProvider;
+import louie.hanse.shareplate.service.LoginService;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+@Slf4j
+public class LogoutInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final LoginService loginService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) {
+        String accessToken = request.getHeader("Access-Token");
+        String refreshToken = request.getHeader("Refresh-Token");
+
+        if (!StringUtils.hasText(accessToken) || !StringUtils.hasText(refreshToken)) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+
+        Long accessTokenMemberId = jwtProvider.decodeMemberId(accessToken);
+        Long refreshTokenMemberId = jwtProvider.decodeMemberId(refreshToken);
+
+        if (!refreshTokenMemberId.equals(accessTokenMemberId)) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+
+        String findRefreshToken = loginService.findRefreshTokenById(refreshTokenMemberId);
+        if (findRefreshToken == null || !findRefreshToken.equals(refreshToken)) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+
+        try {
+            jwtProvider.verifyAccessToken(accessToken);
+            jwtProvider.verifyRefreshToken(refreshToken);
+        } catch (TokenExpiredException e) {
+        } catch (JWTDecodeException e) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        } catch (JWTVerificationException e) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+
+        request.setAttribute("refreshTokenMemberId", refreshTokenMemberId);
+        return true;
+    }
+}

--- a/src/main/java/louie/hanse/shareplate/interceptor/MemberVerificationInterceptor.java
+++ b/src/main/java/louie/hanse/shareplate/interceptor/MemberVerificationInterceptor.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 
 @RequiredArgsConstructor
 @Slf4j
-public class LoginInterceptor implements HandlerInterceptor {
+public class MemberVerificationInterceptor implements HandlerInterceptor {
 
     private final JwtProvider jwtProvider;
 

--- a/src/main/java/louie/hanse/shareplate/interceptor/ReissueAccessTokenInterceptor.java
+++ b/src/main/java/louie/hanse/shareplate/interceptor/ReissueAccessTokenInterceptor.java
@@ -1,0 +1,55 @@
+package louie.hanse.shareplate.interceptor;
+
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import louie.hanse.shareplate.jwt.JwtProvider;
+import louie.hanse.shareplate.service.LoginService;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+public class ReissueAccessTokenInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final LoginService loginService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) {
+
+        String accessToken = request.getHeader("Access-Token");
+        String refreshToken = request.getHeader("Refresh-Token");
+
+        if (!StringUtils.hasText(accessToken) || !StringUtils.hasText(refreshToken)) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+
+        Long accessTokenMemberId = jwtProvider.decodeMemberId(accessToken);
+        Long refreshTokenMemberId = jwtProvider.decodeMemberId(refreshToken);
+
+        try {
+            //TODO refreshToken 만료시 커스텀 code
+            jwtProvider.verifyAccessToken(accessToken);
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+        } catch (TokenExpiredException e) {
+            jwtProvider.verifyRefreshToken(refreshToken);
+
+            if (!refreshTokenMemberId.equals(accessTokenMemberId)) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                return false;
+            }
+
+            String findRefreshToken = loginService.findRefreshTokenById(refreshTokenMemberId);
+            if (findRefreshToken == null || !findRefreshToken.equals(refreshToken)) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                return false;
+            }
+        }
+        request.setAttribute("refreshTokenMemberId", refreshTokenMemberId);
+        return true;
+    }
+}

--- a/src/main/java/louie/hanse/shareplate/web/controller/LoginController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/LoginController.java
@@ -77,7 +77,7 @@ public class LoginController {
                 return;
             }
             String findRefreshToken = loginService.findRefreshTokenById(refreshTokenMemberId);
-            if (findRefreshToken.equals(refreshToken) || findRefreshToken == null) {
+            if (findRefreshToken == null || findRefreshToken.equals(refreshToken)) {
                 response.setStatus(HttpStatus.UNAUTHORIZED.value());
                 return;
             }
@@ -100,7 +100,7 @@ public class LoginController {
             return;
         }
         String findRefreshToken = loginService.findRefreshTokenById(refreshTokenMemberId);
-        if (!findRefreshToken.equals(refreshToken) || findRefreshToken == null) {
+        if (findRefreshToken == null || !findRefreshToken.equals(refreshToken)) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             return;
         }


### PR DESCRIPTION
## 📃 Description
만료된 AccessToken을 재발급 할 수 있는 기능을 구현한다.

## ➡️ Request

### Header

GET `/reissue/access-token`

Access-Token: `만료된 AccessToken`

Refresh-Token: `만료되지 않은 RefreshToken`

### Body

```json
{}
```

## ⬅️ Response

### Header

http status : `200`

Access-Token: `재발급된 AccessToken`

### Body

```json
{}
```

## ☑ Todo
- [x] AcessToken 정상적으로 재발급 됐을 시 처리
- [x] AcessToken 만료되지 않았거나, Token 내 Id 불일치 시 처리
- [x] 인터셉터 처리(logout, reissueAccessToken)