### PR TITLE
채팅 읽은 시간 갱신 기능 구현

### DIFF
--- a/src/main/java/louie/hanse/shareplate/config/WebConfig.java
+++ b/src/main/java/louie/hanse/shareplate/config/WebConfig.java
@@ -33,7 +33,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new MemberVerificationInterceptor(jwtProvider))
             .order(1)
             .addPathPatterns("/members", "/members/location", "/shares", "/shares/mine",
-                "/shares/{id}", "/shares/{id}/entry", "/wish-list", "/chatrooms/{id}")
+                "/shares/{id}", "/shares/{id}/entry", "/wish-list", "/chatrooms/{id}",
+                "/chat-logs/update-read-time")
             .excludePathPatterns("/shares/recommendation");
 
         registry.addInterceptor(new LogoutInterceptor(jwtProvider, loginService))

--- a/src/main/java/louie/hanse/shareplate/service/ChatLogService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ChatLogService.java
@@ -1,0 +1,33 @@
+package louie.hanse.shareplate.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import louie.hanse.shareplate.domain.ChatLog;
+import louie.hanse.shareplate.domain.ChatRoom;
+import louie.hanse.shareplate.domain.Member;
+import louie.hanse.shareplate.repository.ChatLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatLogService {
+
+    private final ChatLogRepository chatLogRepository;
+    private final MemberService memberService;
+    private final ChatRoomService chatRoomService;
+
+    @Transactional
+    public void updateRecentReadDateTime(Long memberId, Long chatRoomId) {
+        Optional<ChatLog> chatLogOptional = chatLogRepository.findByMemberIdAndChatRoomId(
+            memberId, chatRoomId);
+        if (chatLogOptional.isPresent()) {
+            chatLogOptional.get().updateRecentReadDatetime();
+        } else {
+            Member member = memberService.findByIdOrElseThrow(memberId);
+            ChatRoom chatRoom = chatRoomService.findByIdOrElseThrow(chatRoomId);
+            chatLogRepository.save(new ChatLog(member, chatRoom));
+        }
+    }
+}

--- a/src/main/java/louie/hanse/shareplate/web/controller/ChatLogController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/ChatLogController.java
@@ -1,0 +1,24 @@
+package louie.hanse.shareplate.web.controller;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import louie.hanse.shareplate.service.ChatLogService;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatLogController {
+
+    private final ChatLogService chatLogService;
+
+    @PutMapping("/chat-logs/update-read-time")
+    public void updateRecentReadDateTime(@RequestBody Map<String, Long> map,
+        HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        Long chatRoomId = map.get("chatRoomId");
+        chatLogService.updateRecentReadDateTime(memberId, chatRoomId);
+    }
+}


### PR DESCRIPTION
## 📃 Description
💬 안읽은 채팅의 개수를 구하기 위해 채팅 읽은 시간 갱신한다.

## ➡️ Request

### Header

Authorization : `AccessToken`

PUT : `/chats/update-read-time`

### Body

```json
{
	"chatRoomId" : 1
}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{}
```

## ☑ Todo
