### PR TITLE
채팅방 리스트 조회 기능 구현하기

### DIFF
--- a/src/main/java/louie/hanse/shareplate/config/WebConfig.java
+++ b/src/main/java/louie/hanse/shareplate/config/WebConfig.java
@@ -34,7 +34,7 @@ public class WebConfig implements WebMvcConfigurer {
             .order(1)
             .addPathPatterns("/members", "/members/location", "/shares", "/shares/mine",
                 "/shares/{id}", "/shares/{id}/entry", "/wish-list", "/chatrooms/{id}",
-                "/chat-logs/update-read-time", "/chats/unread", "/chatroom-members")
+                "/chat-logs/update-read-time", "/chats/unread", "/chatroom-members", "/chatrooms")
             .excludePathPatterns("/shares/recommendation", "/shares/writer");
 
         registry.addInterceptor(new LogoutInterceptor(jwtProvider, loginService))

--- a/src/main/java/louie/hanse/shareplate/repository/ChatRepository.java
+++ b/src/main/java/louie/hanse/shareplate/repository/ChatRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRepository extends JpaRepository<Chat, Long>, CustomChatRepository {
 
+    Chat findTopByChatRoomIdOrderByWrittenDateTimeDesc(Long chatRoomId);
 }

--- a/src/main/java/louie/hanse/shareplate/repository/ChatRoomRepository.java
+++ b/src/main/java/louie/hanse/shareplate/repository/ChatRoomRepository.java
@@ -1,8 +1,14 @@
 package louie.hanse.shareplate.repository;
 
+import java.util.List;
 import louie.hanse.shareplate.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
+    @Query("select c from ChatRoom c " +
+        "join c.chatRoomMembers m on m.member.id = :memberId")
+    List<ChatRoom> findAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/louie/hanse/shareplate/repository/CustomChatRepository.java
+++ b/src/main/java/louie/hanse/shareplate/repository/CustomChatRepository.java
@@ -2,5 +2,7 @@ package louie.hanse.shareplate.repository;
 
 public interface CustomChatRepository {
 
-    int getUnread(Long memberId);
+    int getTotalUnread(Long memberId);
+
+    int getUnread(Long memberId, Long chatRoomId);
 }

--- a/src/main/java/louie/hanse/shareplate/service/ChatRoomService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ChatRoomService.java
@@ -1,13 +1,18 @@
 package louie.hanse.shareplate.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import louie.hanse.shareplate.domain.Chat;
 import louie.hanse.shareplate.domain.ChatLog;
 import louie.hanse.shareplate.domain.ChatRoom;
 import louie.hanse.shareplate.domain.Member;
 import louie.hanse.shareplate.repository.ChatLogRepository;
+import louie.hanse.shareplate.repository.ChatRepository;
 import louie.hanse.shareplate.repository.ChatRoomRepository;
 import louie.hanse.shareplate.web.dto.chatroom.ChatRoomDetailResponse;
+import louie.hanse.shareplate.web.dto.chatroom.ChatRoomListResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +23,7 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatLogRepository chatLogRepository;
+    private final ChatRepository chatRepository;
     private final MemberService memberService;
 
     @Transactional
@@ -36,8 +42,21 @@ public class ChatRoomService {
         return new ChatRoomDetailResponse(chatRoom, member);
     }
 
+
+    public List<ChatRoomListResponse> getList(Long memberId) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllByMemberId(memberId);
+        List<ChatRoomListResponse> chatRoomList = new ArrayList<>();
+        for (ChatRoom chatRoom : chatRooms) {
+            int unreadCount = chatRepository.getUnread(memberId, chatRoom.getId());
+            Chat chat = chatRepository.findTopByChatRoomIdOrderByWrittenDateTimeDesc(chatRoom.getId());
+            ChatRoomListResponse chatRoomListResponse = new ChatRoomListResponse(chatRoom, chat,
+                unreadCount);
+            chatRoomList.add(chatRoomListResponse);
+        }
+        return chatRoomList;
+    }
+
     public ChatRoom findByIdOrElseThrow(Long id) {
         return chatRoomRepository.findById(id).orElseThrow();
     }
-
 }

--- a/src/main/java/louie/hanse/shareplate/service/ChatRoomService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ChatRoomService.java
@@ -42,15 +42,15 @@ public class ChatRoomService {
         return new ChatRoomDetailResponse(chatRoom, member);
     }
 
-
     public List<ChatRoomListResponse> getList(Long memberId) {
         List<ChatRoom> chatRooms = chatRoomRepository.findAllByMemberId(memberId);
         List<ChatRoomListResponse> chatRoomList = new ArrayList<>();
         for (ChatRoom chatRoom : chatRooms) {
             int unreadCount = chatRepository.getUnread(memberId, chatRoom.getId());
-            Chat chat = chatRepository.findTopByChatRoomIdOrderByWrittenDateTimeDesc(chatRoom.getId());
+            Chat chat = chatRepository
+                .findTopByChatRoomIdOrderByWrittenDateTimeDesc(chatRoom.getId());
             ChatRoomListResponse chatRoomListResponse = new ChatRoomListResponse(chatRoom, chat,
-                unreadCount);
+                unreadCount, memberId);
             chatRoomList.add(chatRoomListResponse);
         }
         return chatRoomList;

--- a/src/main/java/louie/hanse/shareplate/service/ChatService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ChatService.java
@@ -26,7 +26,7 @@ public class ChatService {
         return chatRepository.save(chat);
     }
 
-    public int getUnread(Long memberId) {
-        return chatRepository.getUnread(memberId);
+    public int getTotalUnread(Long memberId) {
+        return chatRepository.getTotalUnread(memberId);
     }
 }

--- a/src/main/java/louie/hanse/shareplate/service/ShareService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ShareService.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.domain.ChatRoom;
+import louie.hanse.shareplate.domain.Entry;
 import louie.hanse.shareplate.domain.Member;
 import louie.hanse.shareplate.domain.Share;
 import louie.hanse.shareplate.exception.GlobalException;
@@ -67,6 +68,8 @@ public class ShareService {
             String uploadedImageUrl = uploadImage(image);
             share.addShareImage(uploadedImageUrl);
         }
+        Entry entry = new Entry(share, member);
+        entryRepository.save(entry);
         new ChatRoom(member, share);
         shareRepository.save(share);
     }

--- a/src/main/java/louie/hanse/shareplate/web/controller/ChatController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/ChatController.java
@@ -19,7 +19,7 @@ public class ChatController {
     @GetMapping("/unread")
     public Map<String, Integer> getUnread(HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        int count = chatService.getUnread(memberId);
+        int count = chatService.getTotalUnread(memberId);
         return Collections.singletonMap("count", count);
     }
 }

--- a/src/main/java/louie/hanse/shareplate/web/controller/ChatRoomController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/ChatRoomController.java
@@ -1,9 +1,11 @@
 package louie.hanse.shareplate.web.controller;
 
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.service.ChatRoomService;
 import louie.hanse.shareplate.web.dto.chatroom.ChatRoomDetailResponse;
+import louie.hanse.shareplate.web.dto.chatroom.ChatRoomListResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,9 +17,16 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
     @GetMapping("/chatrooms/{id}")
-    public ChatRoomDetailResponse chatRoomDetail(@PathVariable Long id, HttpServletRequest request) {
+    public ChatRoomDetailResponse chatRoomDetail(@PathVariable Long id,
+        HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
         return chatRoomService.getDetail(id, memberId);
+    }
+
+    @GetMapping("/chatrooms")
+    public List<ChatRoomListResponse> chatRoomList(HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        return chatRoomService.getList(memberId);
     }
 
 }

--- a/src/main/java/louie/hanse/shareplate/web/dto/chatroom/ChatRoomListResponse.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/chatroom/ChatRoomListResponse.java
@@ -1,0 +1,41 @@
+package louie.hanse.shareplate.web.dto.chatroom;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import louie.hanse.shareplate.domain.Chat;
+import louie.hanse.shareplate.domain.ChatRoom;
+import louie.hanse.shareplate.domain.Entry;
+import louie.hanse.shareplate.domain.Member;
+
+@NoArgsConstructor
+@Getter
+public class ChatRoomListResponse {
+
+    private Long id;
+    private String shareThumbnailImageUrl;
+    private int currentRecruitment;
+    private String recentMessage;
+    private LocalDateTime recentMessageDataTime;
+    private List<String> recruitmentMemberNicknames;
+    private List<String> recruitmentMemberImageUrls;
+    private int unreadCount;
+
+    public ChatRoomListResponse(ChatRoom chatRoom, Chat chat, int unreadCount) {
+        this.id = chatRoom.getId();
+        this.shareThumbnailImageUrl = chatRoom.getShare().getShareImages().get(0).getImageUrl();
+        this.currentRecruitment = chatRoom.getShare().getCurrentRecruitment();
+        this.recentMessage = chat.getContents();
+        this.recentMessageDataTime = chat.getWrittenDateTime();
+        this.recruitmentMemberNicknames = chatRoom.getShare().getEntries().stream()
+            .map(Entry::getMember).map(
+                Member::getNickname).collect(Collectors.toList());
+        this.recruitmentMemberImageUrls = chatRoom.getShare().getEntries().stream()
+            .map(Entry::getMember).map(Member::getThumbnailImageUrl).collect(
+                Collectors.toList());
+        this.unreadCount = unreadCount;
+    }
+
+}

--- a/src/main/java/louie/hanse/shareplate/web/dto/chatroom/ChatRoomListResponse.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/chatroom/ChatRoomListResponse.java
@@ -23,18 +23,18 @@ public class ChatRoomListResponse {
     private List<String> recruitmentMemberImageUrls;
     private int unreadCount;
 
-    public ChatRoomListResponse(ChatRoom chatRoom, Chat chat, int unreadCount) {
+    public ChatRoomListResponse(ChatRoom chatRoom, Chat chat, int unreadCount, Long memberId) {
         this.id = chatRoom.getId();
         this.shareThumbnailImageUrl = chatRoom.getShare().getShareImages().get(0).getImageUrl();
         this.currentRecruitment = chatRoom.getShare().getCurrentRecruitment();
         this.recentMessage = chat.getContents();
         this.recentMessageDataTime = chat.getWrittenDateTime();
         this.recruitmentMemberNicknames = chatRoom.getShare().getEntries().stream()
-            .map(Entry::getMember).map(
-                Member::getNickname).collect(Collectors.toList());
+            .map(Entry::getMember).filter(member -> !member.getId().equals(memberId))
+            .map(Member::getNickname).collect(Collectors.toList());
         this.recruitmentMemberImageUrls = chatRoom.getShare().getEntries().stream()
-            .map(Entry::getMember).map(Member::getThumbnailImageUrl).collect(
-                Collectors.toList());
+            .map(Entry::getMember).filter(member -> !member.getId().equals(memberId))
+            .map(Member::getThumbnailImageUrl).collect(Collectors.toList());
         this.unreadCount = unreadCount;
     }
 

--- a/src/main/java/louie/hanse/shareplate/web/dto/share/ShareDetailResponse.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/share/ShareDetailResponse.java
@@ -47,12 +47,10 @@ public class ShareDetailResponse {
         this.originalPrice = share.getOriginalPrice();
         this.currentRecruitment = share.getCurrentRecruitment();
         this.finalRecruitment = share.getRecruitment();
-        List<String> recruitmentMemberThumbnailImageUrls = share.getEntries().stream()
+        this.recruitmentMemberThumbnailImageUrls = share.getEntries().stream()
             .map(Entry::getMember)
             .map(Member::getThumbnailImageUrl)
             .collect(Collectors.toList());
-        recruitmentMemberThumbnailImageUrls.add(share.getWriter().getThumbnailImageUrl());
-        this.recruitmentMemberThumbnailImageUrls = recruitmentMemberThumbnailImageUrls;
         this.createdDateTime = share.getCreatedDateTime();
         this.appointmentDateTime = share.getAppointmentDateTime();
         this.wish = wish;


### PR DESCRIPTION
## 📃 Description
💬 참가한 채팅 목록을 조회한다.

## ➡️ Request

### Header

Authorization : `AccessToken`

GET `/chatrooms`

### Body

```json
{}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{
	"shareThumbnailImageUrl": "https://s3~~",
	"currentRecruitment": 3,
	"recentMessage": "쿨거래 가능합니까?",
	"recentMessageDateTime": "2022-12-30 14:00",
	"recruitmentMemberNicknames": [
		"나는야", "잉어킹"
	], 
	"recruitmentMemberImageUrls": [
		"https://s3~~", 
		"https://s3~~"
	], 
}
```

## ☑ Todo
