### PR TITLE
쉐어 등록 기능 실패케이스 구현

### DIFF
--- a/src/main/java/louie/hanse/shareplate/exception/type/MemberExceptionType.java
+++ b/src/main/java/louie/hanse/shareplate/exception/type/MemberExceptionType.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 public enum MemberExceptionType implements ExceptionType {
     MEMBER_NOT_FOUND("MEMBER001", "존재하지 않는 회원입니다.", BAD_REQUEST),
-    NOT_SUPPORT_IMAGE_TYPE("MEMBER002", "이미지 형식의 파일이 아닙니다.", BAD_REQUEST),
+    NOT_SUPPORT_IMAGE_TYPE("MEMBER002", "회원 이미지 형식의 파일이 아닙니다.", BAD_REQUEST),
     EMPTY_MEMBER_INFO("MEMBER003", "요청한 회원정보 값이 비어있습니다.", BAD_REQUEST),
     EMPTY_LOCATION("MEMBER004", "요청한 위치정보 값이 비어있습니다.", BAD_REQUEST),
     NOT_LOGIN_MEMBER("MEMBER005", "로그인되지 않은 회원입니다.", UNAUTHORIZED);

--- a/src/main/java/louie/hanse/shareplate/exception/type/ShareExceptionType.java
+++ b/src/main/java/louie/hanse/shareplate/exception/type/ShareExceptionType.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum ShareExceptionType implements ExceptionType {
     EMPTY_SHARE_INFO("SHARE001", "요청한 쉐어정보 값이 비어있습니다.", BAD_REQUEST),
     IMAGE_LIMIT_EXCEEDED("SHARE002", "이미지 5개를 초과하였습니다.", BAD_REQUEST),
-    NOT_SUPPORT_IMAGE_TYPE("SHARE003", "이미지 형식의 파일이 아닙니다.", BAD_REQUEST),
+    NOT_SUPPORT_IMAGE_TYPE("SHARE003", "쉐어 이미지 형식의 파일이 아닙니다.", BAD_REQUEST),
     SHARE_INFO_IS_NEGATIVE("SHARE004", "요청값은 양수여야 합니다.", BAD_REQUEST),
     PAST_CLOSED_DATE_TIME("SHARE005", "약속 시간은 현재 시간 이후로 설정해야 합니다.", BAD_REQUEST),
     OUT_OF_SCOPE_FOR_KOREA("SHARE006", "해당 위도, 경도는 대한민국의 범위를 벗어났습니다.", BAD_REQUEST),

--- a/src/main/java/louie/hanse/shareplate/validator/LatitudeValidator.java
+++ b/src/main/java/louie/hanse/shareplate/validator/LatitudeValidator.java
@@ -1,0 +1,19 @@
+package louie.hanse.shareplate.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import louie.hanse.shareplate.exception.type.ShareExceptionType;
+
+public class LatitudeValidator implements ConstraintValidator<ValidLatitude, Double>  {
+
+    @Override
+    public boolean isValid(Double latitude, ConstraintValidatorContext context) {
+        if (!(33.1 <= latitude && latitude <= 38.45)) {
+            context.buildConstraintViolationWithTemplate(
+                    ShareExceptionType.OUT_OF_SCOPE_FOR_KOREA.getMessage())
+                .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/louie/hanse/shareplate/validator/LongitudeValidator.java
+++ b/src/main/java/louie/hanse/shareplate/validator/LongitudeValidator.java
@@ -1,0 +1,19 @@
+package louie.hanse.shareplate.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import louie.hanse.shareplate.exception.type.ShareExceptionType;
+
+public class LongitudeValidator implements ConstraintValidator<ValidLongitude, Double> {
+
+    @Override
+    public boolean isValid(Double longitude, ConstraintValidatorContext context) {
+        if (!(125.06666667 <= longitude && longitude <= 131.87222222)) {
+            context.buildConstraintViolationWithTemplate(
+                    ShareExceptionType.OUT_OF_SCOPE_FOR_KOREA.getMessage())
+                .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/louie/hanse/shareplate/validator/MultipartFileValidator.java
+++ b/src/main/java/louie/hanse/shareplate/validator/MultipartFileValidator.java
@@ -1,0 +1,29 @@
+package louie.hanse.shareplate.validator;
+
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import louie.hanse.shareplate.exception.type.ShareExceptionType;
+import org.springframework.http.MediaType;
+import org.springframework.web.multipart.MultipartFile;
+
+public class MultipartFileValidator implements ConstraintValidator<ValidShareImage, MultipartFile> {
+
+    private static final List<String> enableContentTypes = createEnableContentTypes();
+
+    @Override
+    public boolean isValid(MultipartFile multipartFile, ConstraintValidatorContext context) {
+        String contentType = multipartFile.getContentType();
+        if (!enableContentTypes.contains(contentType)) {
+            context.buildConstraintViolationWithTemplate(
+                ShareExceptionType.NOT_SUPPORT_IMAGE_TYPE.getMessage())
+                .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+
+    private static List<String> createEnableContentTypes() {
+        return List.of(MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE);
+    }
+}

--- a/src/main/java/louie/hanse/shareplate/validator/ValidLatitude.java
+++ b/src/main/java/louie/hanse/shareplate/validator/ValidLatitude.java
@@ -1,0 +1,21 @@
+package louie.hanse.shareplate.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {LatitudeValidator.class})
+public @interface ValidLatitude {
+    String message() default "해당 위도, 경도는 대한민국의 범위를 벗어났습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/louie/hanse/shareplate/validator/ValidLongitude.java
+++ b/src/main/java/louie/hanse/shareplate/validator/ValidLongitude.java
@@ -1,0 +1,21 @@
+package louie.hanse.shareplate.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {LongitudeValidator.class})
+public @interface ValidLongitude {
+    String message() default "해당 위도, 경도는 대한민국의 범위를 벗어났습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/louie/hanse/shareplate/validator/ValidShareImage.java
+++ b/src/main/java/louie/hanse/shareplate/validator/ValidShareImage.java
@@ -1,0 +1,21 @@
+package louie.hanse.shareplate.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {MultipartFileValidator.class})
+public @interface ValidShareImage {
+    String message() default "쉐어 이미지 형식의 파일이 아닙니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/louie/hanse/shareplate/web/controller/ShareController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/ShareController.java
@@ -3,6 +3,8 @@ package louie.hanse.shareplate.web.controller;
 import java.io.IOException;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.service.NotificationService;
@@ -36,7 +38,7 @@ public class ShareController {
     private final NotificationService notificationService;
 
     @PostMapping
-    public void register(ShareRegisterRequest shareRegisterRequest, HttpServletRequest request)
+    public void register(@Valid ShareRegisterRequest shareRegisterRequest, HttpServletRequest request)
         throws IOException {
         Long memberId = (Long) request.getAttribute("memberId");
         Long shareId = shareService.register(shareRegisterRequest, memberId);
@@ -57,7 +59,7 @@ public class ShareController {
     }
 
     @GetMapping("/{id}")
-    public ShareDetailResponse getDetail(@PathVariable Long id, HttpServletRequest request) {
+    public ShareDetailResponse getDetail(@PathVariable(required = false) @NotNull Long id, HttpServletRequest request) {
         String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
         return shareService.getDetail(id, accessToken);
     }

--- a/src/main/java/louie/hanse/shareplate/web/dto/share/ShareRegisterRequest.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/share/ShareRegisterRequest.java
@@ -2,29 +2,75 @@ package louie.hanse.shareplate.web.dto.share;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import louie.hanse.shareplate.domain.Member;
 import louie.hanse.shareplate.domain.Share;
 import louie.hanse.shareplate.type.ShareType;
+import louie.hanse.shareplate.validator.ValidLatitude;
+import louie.hanse.shareplate.validator.ValidLongitude;
+import louie.hanse.shareplate.validator.ValidShareImage;
 import org.springframework.web.multipart.MultipartFile;
 
 @Setter
+@NoArgsConstructor
 public class ShareRegisterRequest {
 
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
     private ShareType type;
-    private List<MultipartFile> images;
+
+    @NotEmpty(message = "요청한 쉐어정보 값이 비어있습니다.")
+    @Size(max = 5, message = "이미지 5개를 초과하였습니다.")
+    private List<@Valid @NotNull @ValidShareImage MultipartFile> images;
+
+    @NotEmpty(message = "요청한 쉐어정보 값이 비어있습니다.")
     private String title;
-    private int price;
-    private int originalPrice;
-    private int recruitment;
+
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+    @Positive(message = "요청값은 양수여야 합니다.")
+    private Integer price;
+
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+    @Positive(message = "요청값은 양수여야 합니다.")
+    private Integer originalPrice;
+
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+    @Positive(message = "요청값은 양수여야 합니다.")
+    private Integer recruitment;
+
+    @NotEmpty(message = "요청한 쉐어정보 값이 비어있습니다.")
     private String location;
+
+    @NotEmpty(message = "요청한 쉐어정보 값이 비어있습니다.")
     private String locationGuide;
-    private boolean locationNegotiation;
-    private boolean priceNegotiation;
-    private List<String> hashtags;
-    private double latitude;
-    private double longitude;
+
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+    private Boolean locationNegotiation;
+
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+    private Boolean priceNegotiation;
+
+    private List<@Valid @NotEmpty(message = "요청한 쉐어정보 값이 비어있습니다.") String> hashtags;
+
+    @ValidLatitude
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+    private Double latitude;
+
+    @ValidLongitude
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+    private Double longitude;
+
+    @NotEmpty(message = "요청한 쉐어정보 값이 비어있습니다.")
     private String description;
+
+    @Future(message = "약속 시간은 현재 시간 이후로 설정해야 합니다.")
+    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
     private LocalDateTime closedDateTime;
 
     public Share toEntity(Member member) {

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareDeleteIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareDeleteIntegrationTest.java
@@ -10,10 +10,12 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 import louie.hanse.shareplate.integration.InitIntegrationTest;
 import louie.hanse.shareplate.jwt.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+@DisplayName("쉐어 삭제 통합 테스트")
 class ShareDeleteIntegrationTest extends InitIntegrationTest {
 
     @Autowired

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareIntegrationTestUtils.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareIntegrationTestUtils.java
@@ -1,0 +1,15 @@
+package louie.hanse.shareplate.integration.share;
+
+import io.restassured.builder.MultiPartSpecBuilder;
+import io.restassured.specification.MultiPartSpecification;
+import java.nio.charset.StandardCharsets;
+
+class ShareIntegrationTestUtils {
+
+    public static MultiPartSpecification createMultiPartSpecification(String name, Object value) {
+        return new MultiPartSpecBuilder(value)
+            .controlName(name)
+            .charset(StandardCharsets.UTF_8)
+            .build();
+    }
+}

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareRegisterIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareRegisterIntegrationTest.java
@@ -1,0 +1,284 @@
+package louie.hanse.shareplate.integration.share;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.MULTIPART;
+import static louie.hanse.shareplate.exception.type.ShareExceptionType.EMPTY_SHARE_INFO;
+import static louie.hanse.shareplate.exception.type.ShareExceptionType.IMAGE_LIMIT_EXCEEDED;
+import static louie.hanse.shareplate.exception.type.ShareExceptionType.NOT_SUPPORT_IMAGE_TYPE;
+import static louie.hanse.shareplate.exception.type.ShareExceptionType.OUT_OF_SCOPE_FOR_KOREA;
+import static louie.hanse.shareplate.exception.type.ShareExceptionType.PAST_CLOSED_DATE_TIME;
+import static louie.hanse.shareplate.integration.share.ShareIntegrationTestUtils.createMultiPartSpecification;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_PDF_VALUE;
+import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import louie.hanse.shareplate.config.S3MockConfig;
+import louie.hanse.shareplate.integration.InitIntegrationTest;
+import louie.hanse.shareplate.jwt.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+
+@Import(S3MockConfig.class)
+@DisplayName("쉐어 등록 통합 테스트")
+class ShareRegisterIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Test
+    void 음식_공유를_하기_위해_쉐어를_등록한다() {
+        String accessToken = jwtProvider.createAccessToken(2355841033L);
+
+        given(documentationSpec)
+            .filter(document("share-register-post"))
+            .header(AUTHORIZATION, accessToken)
+            .contentType(MULTIPART)
+            .multiPart("images", "test1.jpg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test1.jpeg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test2.png", "def".getBytes(), IMAGE_PNG_VALUE)
+            .multiPart(createMultiPartSpecification("title", "제목"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그1"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그2"))
+            .multiPart(createMultiPartSpecification("locationGuide", "강남역 파출소 앞"))
+            .multiPart(createMultiPartSpecification("location", "강남역"))
+            .multiPart(createMultiPartSpecification("description", "설명"))
+            .formParam("type", "delivery")
+            .formParam("price", 10000)
+            .formParam("originalPrice", 30000)
+            .formParam("recruitment", 3)
+            .formParam("locationNegotiation", true)
+            .formParam("priceNegotiation", true)
+            .formParam("latitude", 37.524159)
+            .formParam("longitude", 126.872879)
+            .formParam("closedDateTime", "2022-12-30 14:00")
+
+            .when()
+            .post("/shares")
+
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+//    TODO 어떤 필드가 검증에 실패했는지도 메세지로 나타내기, closedDateTime 패턴 형식까지 검증하기
+    @Test
+    void 쉐어_등록_요청_시_쉐어_이미지를_입력받지_못한_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.createAccessToken(2355841033L);
+
+        given(documentationSpec)
+            .filter(document("share-register-post"))
+            .header(AUTHORIZATION, accessToken)
+            .contentType(MULTIPART)
+            .multiPart(createMultiPartSpecification("title", "제목"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그1"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그2"))
+            .multiPart(createMultiPartSpecification("locationGuide", "강남역 파출소 앞"))
+            .multiPart(createMultiPartSpecification("location", "강남역"))
+            .multiPart(createMultiPartSpecification("description", "설명"))
+            .formParam("type", "delivery")
+            .formParam("price", 10000)
+            .formParam("originalPrice", 30000)
+            .formParam("recruitment", 3)
+            .formParam("locationNegotiation", true)
+            .formParam("priceNegotiation", true)
+            .formParam("latitude", 37.524159)
+            .formParam("longitude", 126.872879)
+            .formParam("closedDateTime", "2022-12-30 14:00")
+
+            .when()
+            .post("/shares")
+
+            .then()
+            .statusCode(EMPTY_SHARE_INFO.getStatusCode().value())
+            .body("errorCode", equalTo(EMPTY_SHARE_INFO.getErrorCode()))
+            .body("message", equalTo(EMPTY_SHARE_INFO.getMessage()));
+    }
+
+    @Test
+    void 지원하지_않은_이미지_형식을_입력받으면_예외를_발생시킨다() {
+        String accessToken = jwtProvider.createAccessToken(2355841033L);
+
+        given(documentationSpec)
+            .filter(document("share-register-post"))
+            .header(AUTHORIZATION, accessToken)
+            .contentType(MULTIPART)
+            .multiPart("images", "test1.txt", "abc".getBytes(), TEXT_PLAIN_VALUE)
+            .multiPart("images", "test2.pdf", "def".getBytes(), APPLICATION_PDF_VALUE)
+            .multiPart(createMultiPartSpecification("title", "제목"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그1"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그2"))
+            .multiPart(createMultiPartSpecification("locationGuide", "강남역 파출소 앞"))
+            .multiPart(createMultiPartSpecification("location", "강남역"))
+            .multiPart(createMultiPartSpecification("description", "설명"))
+            .formParam("type", "delivery")
+            .formParam("price", 10000)
+            .formParam("originalPrice", 30000)
+            .formParam("recruitment", 3)
+            .formParam("locationNegotiation", true)
+            .formParam("priceNegotiation", true)
+            .formParam("latitude", 37.524159)
+            .formParam("longitude", 126.872879)
+            .formParam("closedDateTime", "2022-12-30 14:00")
+
+            .when()
+            .post("/shares")
+
+            .then()
+            .statusCode(NOT_SUPPORT_IMAGE_TYPE.getStatusCode().value())
+            .body("errorCode", equalTo(NOT_SUPPORT_IMAGE_TYPE.getErrorCode()))
+            .body("message", equalTo(NOT_SUPPORT_IMAGE_TYPE.getMessage()));
+    }
+
+    @Test
+    void 쉐어_등록_요청_시_쉐어_이미지는_5개를_초과할_수_없다() {
+        String accessToken = jwtProvider.createAccessToken(2355841033L);
+
+        given(documentationSpec)
+            .filter(document("share-register-post"))
+            .header(AUTHORIZATION, accessToken)
+            .contentType(MULTIPART)
+            .multiPart("images", "test1.jpg", "abc1".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test2.jpg", "abc2".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test3.jpg", "abc3".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test4.jpg", "abc4".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test5.jpg", "abc5".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test6.jpg", "abc6".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart(createMultiPartSpecification("title", "제목"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그1"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그2"))
+            .multiPart(createMultiPartSpecification("locationGuide", "강남역 파출소 앞"))
+            .multiPart(createMultiPartSpecification("location", "강남역"))
+            .multiPart(createMultiPartSpecification("description", "설명"))
+            .formParam("type", "delivery")
+            .formParam("price", 10000)
+            .formParam("originalPrice", 30000)
+            .formParam("recruitment", 3)
+            .formParam("locationNegotiation", true)
+            .formParam("priceNegotiation", true)
+            .formParam("latitude", 37.524159)
+            .formParam("longitude", 126.872879)
+            .formParam("closedDateTime", "2022-12-30 14:00")
+
+            .when()
+            .post("/shares")
+
+            .then()
+            .statusCode(IMAGE_LIMIT_EXCEEDED.getStatusCode().value())
+            .body("errorCode", equalTo(IMAGE_LIMIT_EXCEEDED.getErrorCode()))
+            .body("message", equalTo(IMAGE_LIMIT_EXCEEDED.getMessage()));
+    }
+
+    @Test
+    void 쉐어_등록_요청_시_대한민국의_위도_범위를_벗어났을_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.createAccessToken(2355841033L);
+
+        given(documentationSpec)
+            .filter(document("share-register-post"))
+            .header(AUTHORIZATION, accessToken)
+            .contentType(MULTIPART)
+            .multiPart("images", "test1.jpg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test1.jpeg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test2.png", "def".getBytes(), IMAGE_PNG_VALUE)
+            .multiPart(createMultiPartSpecification("title", "제목"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그1"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그2"))
+            .multiPart(createMultiPartSpecification("locationGuide", "강남역 파출소 앞"))
+            .multiPart(createMultiPartSpecification("location", "강남역"))
+            .multiPart(createMultiPartSpecification("description", "설명"))
+            .formParam("type", "delivery")
+            .formParam("price", 10000)
+            .formParam("originalPrice", 30000)
+            .formParam("recruitment", 3)
+            .formParam("locationNegotiation", true)
+            .formParam("priceNegotiation", true)
+            .formParam("latitude", 39)
+            .formParam("longitude", 126.872879)
+            .formParam("closedDateTime", "2022-12-30 14:00")
+
+            .when()
+            .post("/shares")
+
+            .then()
+            .statusCode(OUT_OF_SCOPE_FOR_KOREA.getStatusCode().value())
+            .body("errorCode", equalTo(OUT_OF_SCOPE_FOR_KOREA.getErrorCode()))
+            .body("message", equalTo(OUT_OF_SCOPE_FOR_KOREA.getMessage()));
+    }
+
+    @Test
+    void 쉐어_등록_요청_시_대한민국의_경도_범위를_벗어났을_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.createAccessToken(2355841033L);
+
+        given(documentationSpec)
+            .filter(document("share-register-post"))
+            .header(AUTHORIZATION, accessToken)
+            .contentType(MULTIPART)
+            .multiPart("images", "test1.jpg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test1.jpeg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test2.png", "def".getBytes(), IMAGE_PNG_VALUE)
+            .multiPart(createMultiPartSpecification("title", "제목"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그1"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그2"))
+            .multiPart(createMultiPartSpecification("locationGuide", "강남역 파출소 앞"))
+            .multiPart(createMultiPartSpecification("location", "강남역"))
+            .multiPart(createMultiPartSpecification("description", "설명"))
+            .formParam("type", "delivery")
+            .formParam("price", 10000)
+            .formParam("originalPrice", 30000)
+            .formParam("recruitment", 3)
+            .formParam("locationNegotiation", true)
+            .formParam("priceNegotiation", true)
+            .formParam("latitude", 37.524159)
+            .formParam("longitude", 123)
+            .formParam("closedDateTime", "2022-12-30 14:00")
+
+            .when()
+            .post("/shares")
+
+            .then()
+            .statusCode(OUT_OF_SCOPE_FOR_KOREA.getStatusCode().value())
+            .body("errorCode", equalTo(OUT_OF_SCOPE_FOR_KOREA.getErrorCode()))
+            .body("message", equalTo(OUT_OF_SCOPE_FOR_KOREA.getMessage()));
+    }
+
+    @Test
+    void 쉐어_등록_요청_시_마감_시간이_과거인_경우_예외를_발생시킨다() {
+        String accessToken = jwtProvider.createAccessToken(2355841033L);
+
+        given(documentationSpec)
+            .filter(document("share-register-post"))
+            .header(AUTHORIZATION, accessToken)
+            .contentType(MULTIPART)
+            .multiPart("images", "test1.jpg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test1.jpeg", "abc".getBytes(), IMAGE_JPEG_VALUE)
+            .multiPart("images", "test2.png", "def".getBytes(), IMAGE_PNG_VALUE)
+            .multiPart(createMultiPartSpecification("title", "제목"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그1"))
+            .multiPart(createMultiPartSpecification("hashtags", "해시태그2"))
+            .multiPart(createMultiPartSpecification("locationGuide", "강남역 파출소 앞"))
+            .multiPart(createMultiPartSpecification("location", "강남역"))
+            .multiPart(createMultiPartSpecification("description", "설명"))
+            .formParam("type", "delivery")
+            .formParam("price", 10000)
+            .formParam("originalPrice", 30000)
+            .formParam("recruitment", 3)
+            .formParam("locationNegotiation", true)
+            .formParam("priceNegotiation", true)
+            .formParam("latitude", 37.524159)
+            .formParam("longitude", 126.872879)
+            .formParam("closedDateTime", "2021-12-30 14:00")
+
+            .when()
+            .post("/shares")
+
+            .then()
+            .statusCode(PAST_CLOSED_DATE_TIME.getStatusCode().value())
+            .body("errorCode", equalTo(PAST_CLOSED_DATE_TIME.getErrorCode()))
+            .body("message", equalTo(PAST_CLOSED_DATE_TIME.getMessage()));
+    }
+}


### PR DESCRIPTION
## 📃 Description
- 쉐어 등록 API와 관련된 실패케이스 구현과 구현한 실패케이스에 대한 테스트를 모두 구현한다.

## ☑ Todo
- [x] `SHARE001` : 요청 시 필드 값이 하나라도 비어있을 때 : `400`
- [x] `SHARE002` : `images`의 개수가 5개를 초과하는 경우 : `400`
- [x] `SHARE003` : `images`가 이미지 형식이 아닌 경우 : `400`
- [x] `SHARE004` : `price`, `originalPrice`, `recruitment`가 음수인 경우 :`400`
- [x] `SHARE005` : `closedDateTime`이 현재 시간보다 이전인 경우 :`400`
- [x] `SHARE006` : 대한민국의 위도, 경도 범위를 벗어난 경우 : `400`
