### PR TITLE
참가한 모든 채팅방에 대한 회원 조회 API 구현

### DIFF
--- a/src/main/java/louie/hanse/shareplate/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/louie/hanse/shareplate/repository/ChatRoomMemberRepository.java
@@ -1,5 +1,6 @@
 package louie.hanse.shareplate.repository;
 
+import java.util.List;
 import louie.hanse.shareplate.domain.ChatRoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +17,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
         @Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
 
     void deleteByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);
+
+    List<ChatRoomMember> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/louie/hanse/shareplate/service/ChatRoomMemberService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ChatRoomMemberService.java
@@ -1,5 +1,7 @@
 package louie.hanse.shareplate.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.domain.ChatRoomMember;
 import louie.hanse.shareplate.domain.Share;
@@ -27,5 +29,12 @@ public class ChatRoomMemberService {
         if (share.isNotEnd()) {
             entryRepository.deleteByMemberIdAndShareId(memberId, share.getId());
         }
+    }
+
+    public List<Long> getIdList(Long memberId) {
+        return chatRoomMemberRepository
+            .findAllByMemberId(memberId).stream()
+            .map(ChatRoomMember::getId)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/louie/hanse/shareplate/web/controller/ChatRoomMemberController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/ChatRoomMemberController.java
@@ -1,10 +1,13 @@
 package louie.hanse.shareplate.web.controller;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.service.ChatRoomMemberService;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomMemberController {
 
     private final ChatRoomMemberService chatRoomMemberService;
+
+    @GetMapping
+    public Map<String, List<Long>> getIdList(HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        List<Long> idList = chatRoomMemberService.getIdList(memberId);
+        return Collections.singletonMap("idList", idList);
+    }
 
     @DeleteMapping
     public void exitChatRoom(@RequestBody Map<String, Long> map, HttpServletRequest request) {

--- a/src/test/java/louie/hanse/shareplate/integration/chatRoomMember/ChatRoomMemberIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/chatRoomMember/ChatRoomMemberIntegrationTest.java
@@ -1,6 +1,7 @@
 package louie.hanse.shareplate.integration.chatRoomMember;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
@@ -34,5 +35,21 @@ class ChatRoomMemberIntegrationTest extends InitIntegrationTest {
 
             .then()
             .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 참가한_모든_채팅방에_대한_회원_정보를_조회한다() {
+        String accessToken = jwtProvider.createAccessToken(2370842997L);
+
+        given(documentationSpec)
+            .filter(document("chatRoomMember-list-get"))
+            .header(AUTHORIZATION, accessToken)
+
+            .when()
+            .get("/chatroom-members")
+
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("idList", hasSize(5));
     }
 }

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareEditIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareEditIntegrationTest.java
@@ -14,7 +14,7 @@ import static louie.hanse.shareplate.exception.type.ShareExceptionType.SHARE_INF
 import static louie.hanse.shareplate.exception.type.ShareExceptionType.SHARE_IS_CANCELED;
 import static louie.hanse.shareplate.exception.type.ShareExceptionType.SHARE_IS_CLOSED;
 import static louie.hanse.shareplate.exception.type.ShareExceptionType.SHARE_NOT_FOUND;
-import static louie.hanse.shareplate.integration.share.ShareIntegrationTestUtils.createMultiPartSpecification;
+import static louie.hanse.shareplate.integration.share.utils.ShareIntegrationTestUtils.createMultiPartSpecification;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareRegisterIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareRegisterIntegrationTest.java
@@ -7,7 +7,7 @@ import static louie.hanse.shareplate.exception.type.ShareExceptionType.IMAGE_LIM
 import static louie.hanse.shareplate.exception.type.ShareExceptionType.NOT_SUPPORT_IMAGE_TYPE;
 import static louie.hanse.shareplate.exception.type.ShareExceptionType.OUT_OF_SCOPE_FOR_KOREA;
 import static louie.hanse.shareplate.exception.type.ShareExceptionType.PAST_CLOSED_DATE_TIME;
-import static louie.hanse.shareplate.integration.share.ShareIntegrationTestUtils.createMultiPartSpecification;
+import static louie.hanse.shareplate.integration.share.utils.ShareIntegrationTestUtils.createMultiPartSpecification;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_PDF_VALUE;

--- a/src/test/java/louie/hanse/shareplate/integration/share/utils/ShareIntegrationTestUtils.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/utils/ShareIntegrationTestUtils.java
@@ -1,10 +1,10 @@
-package louie.hanse.shareplate.integration.share;
+package louie.hanse.shareplate.integration.share.utils;
 
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.specification.MultiPartSpecification;
 import java.nio.charset.StandardCharsets;
 
-class ShareIntegrationTestUtils {
+public class ShareIntegrationTestUtils {
 
     public static MultiPartSpecification createMultiPartSpecification(String name, Object value) {
         return new MultiPartSpecBuilder(value)


### PR DESCRIPTION
## 📃 Description
💬 새로 작성된 채팅 내용 알림 API를 구독하기 위한 chatRoomMember의 id 목록을 반환한다.

## ➡️ Request

### Header

Authorization : `AccessToken`

GET : `/chatroom-members`

### Body

```json
{}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{
	"idList": [1, 2, 3]
}
```

## ☑ Todo
