### PR TITLE
쉐어 취소 시 해당 쉐어 참여자들에게 알림 전송, 쉐어에 대한 찜, 참여 모두 삭제하도록 변경

### DIFF
--- a/src/main/java/louie/hanse/shareplate/domain/ActivityNotification.java
+++ b/src/main/java/louie/hanse/shareplate/domain/ActivityNotification.java
@@ -36,4 +36,8 @@ public class ActivityNotification extends Notification {
         super(share, member, type);
         this.activityType = activityType;
     }
+
+    public boolean isDeadLine() {
+        return activityType.isDeadLine();
+    }
 }

--- a/src/main/java/louie/hanse/shareplate/service/NotificationService.java
+++ b/src/main/java/louie/hanse/shareplate/service/NotificationService.java
@@ -104,7 +104,7 @@ public class NotificationService {
     }
 
     @Transactional
-    public void saveActivityNotificationAndSend(Long shareId, Long memberId) {
+    public void saveActivityNotificationAndSend(Long shareId, Long memberId, ActivityType activityType) {
         Share share = shareService.findByIdOrElseThrow(shareId);
         Member member = memberService.findByIdOrElseThrow(memberId);
         List<Entry> entries = entryRepository.findAllByShareIdAndMemberId(shareId,
@@ -114,7 +114,7 @@ public class NotificationService {
         List<ActivityNotificationResponse> responses = new ArrayList<>();
         for (Entry entry : entries) {
             ActivityNotification activityNotification = new ActivityNotification(share,
-                entry.getMember(), NotificationType.ACTIVITY, ActivityType.ENTRY, member);
+                entry.getMember(), NotificationType.ACTIVITY, activityType, member);
             activityNotifications.add(activityNotification);
             responses.add(new ActivityNotificationResponse(activityNotification));
         }

--- a/src/main/java/louie/hanse/shareplate/type/ActivityType.java
+++ b/src/main/java/louie/hanse/shareplate/type/ActivityType.java
@@ -1,5 +1,9 @@
 package louie.hanse.shareplate.type;
 
 public enum ActivityType {
-    ENTRY, DEADLINE
+    ENTRY, DEADLINE, SHARE_CANCEL, ENTRY_CANCEL;
+
+    public boolean isDeadLine() {
+        return this == DEADLINE;
+    }
 }

--- a/src/main/java/louie/hanse/shareplate/web/controller/EntryController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/EntryController.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.service.EntryService;
 import louie.hanse.shareplate.service.NotificationService;
+import louie.hanse.shareplate.type.ActivityType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,7 +38,7 @@ public class EntryController {
         HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
         entryService.entry(shareId, memberId);
-        notificationService.saveActivityNotificationAndSend(shareId, memberId);
+        notificationService.saveActivityNotificationAndSend(shareId, memberId, ActivityType.ENTRY);
     }
 
     @DeleteMapping("/shares/{shareId}/entry")
@@ -46,6 +47,7 @@ public class EntryController {
         HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
         entryService.cancel(shareId, memberId);
+        notificationService.saveActivityNotificationAndSend(shareId, memberId, ActivityType.ENTRY_CANCEL);
     }
 
 }

--- a/src/main/java/louie/hanse/shareplate/web/controller/ShareController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/ShareController.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import louie.hanse.shareplate.service.NotificationService;
 import louie.hanse.shareplate.service.ShareService;
+import louie.hanse.shareplate.type.ActivityType;
 import louie.hanse.shareplate.web.dto.share.ShareCommonResponse;
 import louie.hanse.shareplate.web.dto.share.ShareDetailResponse;
 import louie.hanse.shareplate.web.dto.share.ShareEditRequest;
@@ -75,10 +76,11 @@ public class ShareController {
     }
 
     @DeleteMapping("/{id}")
-    public void cancel(@PathVariable @Positive(message = "쉐어 id는 양수여야 합니다.") Long id
-        , HttpServletRequest request) {
+    public void cancel(@PathVariable @Positive(message = "쉐어 id는 양수여야 합니다.") Long id,
+        HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
         shareService.cancel(id, memberId);
+        notificationService.saveActivityNotificationAndSend(id, memberId, ActivityType.SHARE_CANCEL);
     }
 
     @GetMapping("/recommendation")

--- a/src/main/java/louie/hanse/shareplate/web/dto/notification/ActivityNotificationResponse.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/notification/ActivityNotificationResponse.java
@@ -18,8 +18,8 @@ public class ActivityNotificationResponse {
     private ActivityType activityType;
 
     public ActivityNotificationResponse(ActivityNotification activityNotification) {
-        this.recruitmentMemberNickname = activityNotification.getActivityType().equals(ActivityType.ENTRY) ?
-                activityNotification.getEntryMember().getNickname() : null;
+        this.recruitmentMemberNickname = activityNotification.isDeadLine() ?
+            null : activityNotification.getEntryMember().getNickname();
         this.notificationCreatedDateTime = activityNotification.getCreatedDateTime();
         this.shareTitle = activityNotification.getShare().getTitle();
         this.shareThumbnailImageUrl = activityNotification.getShare().getShareImages().get(0)


### PR DESCRIPTION
## 📃 Description
- [x] 쉐어 취소 시 해당 쉐어 참여자들에게 쉐어 취소 알림 전송
- [x] 해당 쉐어에 대한 찜 모두 삭제
- [x] 해당 쉐어에 대한 참여 모두 삭제

