### PR TITLE
쉐어 추천 API 실패케이스 구현, 쉐어 검색 API 수정

### DIFF
--- a/src/main/java/louie/hanse/shareplate/web/controller/ShareController.java
+++ b/src/main/java/louie/hanse/shareplate/web/controller/ShareController.java
@@ -85,7 +85,7 @@ public class ShareController {
 
     @GetMapping("/recommendation")
     public List<ShareCommonResponse> recommendationAroundMember(
-        ShareRecommendationRequest request) {
+        @Valid ShareRecommendationRequest request) {
         return shareService.recommendationAroundMember(request);
     }
 

--- a/src/main/java/louie/hanse/shareplate/web/dto/share/ShareRecommendationRequest.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/share/ShareRecommendationRequest.java
@@ -2,12 +2,18 @@ package louie.hanse.shareplate.web.dto.share;
 
 import lombok.Getter;
 import lombok.Setter;
+import louie.hanse.shareplate.validator.share.ValidShareLatitude;
+import louie.hanse.shareplate.validator.share.ValidShareLongitude;
 
 @Setter
 @Getter
 public class ShareRecommendationRequest {
 
     private String keyword;
-    private double latitude;
-    private double longitude;
+
+    @ValidShareLatitude
+    private Double latitude;
+
+    @ValidShareLongitude
+    private Double longitude;
 }

--- a/src/main/java/louie/hanse/shareplate/web/dto/share/ShareSearchRequest.java
+++ b/src/main/java/louie/hanse/shareplate/web/dto/share/ShareSearchRequest.java
@@ -1,7 +1,5 @@
 package louie.hanse.shareplate.web.dto.share;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import louie.hanse.shareplate.type.ShareType;
@@ -11,9 +9,8 @@ import louie.hanse.shareplate.validator.share.ValidShareLongitude;
 @Setter
 @Getter
 public class ShareSearchRequest {
-    @NotNull(message = "요청한 쉐어정보 값이 비어있습니다.")
+
     private ShareType type;
-    @NotBlank(message = "요청한 쉐어정보 값이 비어있습니다.")
     private String keyword;
 
     @ValidShareLatitude

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareIntegrationTest.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import louie.hanse.shareplate.config.S3MockConfig;
@@ -22,21 +21,6 @@ class ShareIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     JwtProvider jwtProvider;
-
-    @Test
-    void 검색한_키워드가_포함된_회원_주변의_쉐어를_추천한다() {
-        given(documentationSpec)
-            .filter(document("share-recommendation-get"))
-            .accept(APPLICATION_JSON_VALUE)
-            .param("latitude", 36.6576769)
-            .param("long천itude", 128.3007637)
-
-            .when()
-            .get("/shares/recommendation")
-
-            .then()
-            .statusCode(HttpStatus.OK.value());
-    }
 
     @Test
     void 특정_사용자가_작성한_쉐어를_조회한다() {

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareRecommendationIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareRecommendationIntegrationTest.java
@@ -1,0 +1,82 @@
+package louie.hanse.shareplate.integration.share;
+
+import static io.restassured.RestAssured.given;
+import static louie.hanse.shareplate.exception.type.ShareExceptionType.EMPTY_SHARE_INFO;
+import static louie.hanse.shareplate.exception.type.ShareExceptionType.OUT_OF_SCOPE_FOR_KOREA;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import louie.hanse.shareplate.integration.InitIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("쉐어 추천 통합 테스트")
+class ShareRecommendationIntegrationTest extends InitIntegrationTest {
+
+    @Test
+    void 검색한_키워드가_포함된_회원_주변의_쉐어를_추천한다() {
+        given(documentationSpec)
+            .filter(document("share-recommendation-get"))
+            .accept(APPLICATION_JSON_VALUE)
+            .param("latitude", 36.6576769)
+            .param("longitude", 128.3007637)
+
+            .when()
+            .get("/shares/recommendation")
+
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 위도를_입력하지_않는_경우_예외가_발생한다() {
+        given(documentationSpec)
+            .filter(document("share-recommendation-get"))
+            .accept(APPLICATION_JSON_VALUE)
+            .param("longitude", 128.3007637)
+
+            .when()
+            .get("/shares/recommendation")
+
+            .then()
+            .statusCode(EMPTY_SHARE_INFO.getStatusCode().value())
+            .body("errorCode", equalTo(EMPTY_SHARE_INFO.getErrorCode()))
+            .body("message", equalTo(EMPTY_SHARE_INFO.getMessage()));
+    }
+
+    @Test
+    void 대한민국의_위도_범위를_벗어난_경우_예외를_발생시킨다() {
+        given(documentationSpec)
+            .filter(document("share-recommendation-get"))
+            .accept(APPLICATION_JSON_VALUE)
+            .param("latitude", 39)
+            .param("longitude", 128.3007637)
+
+            .when()
+            .get("/shares/recommendation")
+
+            .then()
+            .statusCode(OUT_OF_SCOPE_FOR_KOREA.getStatusCode().value())
+            .body("errorCode", equalTo(OUT_OF_SCOPE_FOR_KOREA.getErrorCode()))
+            .body("message", equalTo(OUT_OF_SCOPE_FOR_KOREA.getMessage()));
+    }
+
+    @Test
+    void 대한민국의_경도_범위를_벗어난_경우_예외를_발생시킨다() {
+        given(documentationSpec)
+            .filter(document("share-recommendation-get"))
+            .accept(APPLICATION_JSON_VALUE)
+            .param("latitude", 36.6576769)
+            .param("longitude", 123)
+
+            .when()
+            .get("/shares/recommendation")
+
+            .then()
+            .statusCode(OUT_OF_SCOPE_FOR_KOREA.getStatusCode().value())
+            .body("errorCode", equalTo(OUT_OF_SCOPE_FOR_KOREA.getErrorCode()))
+            .body("message", equalTo(OUT_OF_SCOPE_FOR_KOREA.getMessage()));
+    }
+}

--- a/src/test/java/louie/hanse/shareplate/integration/share/ShareSearchIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/share/ShareSearchIntegrationTest.java
@@ -1,8 +1,6 @@
 package louie.hanse.shareplate.integration.share;
 
 import static io.restassured.RestAssured.given;
-import static louie.hanse.shareplate.exception.type.ShareExceptionType.EMPTY_SHARE_INFO;
-import static louie.hanse.shareplate.exception.type.ShareExceptionType.INCORRECT_TYPE_VALUE;
 import static louie.hanse.shareplate.exception.type.ShareExceptionType.OUT_OF_SCOPE_FOR_KOREA;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -52,44 +50,6 @@ class ShareSearchIntegrationTest extends InitIntegrationTest {
             .body("[0].writerId", equalTo(2370842997L))
             .body("[0].createdDateTime", equalTo("2022-08-03 16:00"))
             .body("[0].closedDateTime", equalTo("2023-08-03 16:00"));
-    }
-
-    @Test
-    void 키워드를_입력하지_않는_경우_예외가_발생한다() {
-        given(documentationSpec)
-            .filter(document("share-search-get"))
-            .accept(APPLICATION_JSON_VALUE)
-            .param("type", "delivery")
-            .param("keyword", "   ")
-            .param("latitude", 36.6576769)
-            .param("longitude", 128.3007637)
-
-            .when()
-            .get("/shares")
-
-            .then()
-            .statusCode(EMPTY_SHARE_INFO.getStatusCode().value())
-            .body("errorCode", equalTo(EMPTY_SHARE_INFO.getErrorCode()))
-            .body("message", equalTo(EMPTY_SHARE_INFO.getMessage()));
-    }
-
-    @Test
-    void 유효하지_않은_타입을_입력하지_않는_경우_예외가_발생한다() {
-        given(documentationSpec)
-            .filter(document("share-search-get"))
-            .accept(APPLICATION_JSON_VALUE)
-            .param("type", "ttttttt")
-            .param("keyword", "햄버거")
-            .param("latitude", 36.6576769)
-            .param("longitude", 128.3007637)
-
-            .when()
-            .get("/shares")
-
-            .then()
-            .statusCode(INCORRECT_TYPE_VALUE.getStatusCode().value())
-            .body("errorCode", equalTo(INCORRECT_TYPE_VALUE.getErrorCode()))
-            .body("message", equalTo(INCORRECT_TYPE_VALUE.getMessage()));
     }
 
     @Test


### PR DESCRIPTION
## 📃 Description
- `SHARE006` : 대한민국의 위도 경도 범위를 벗어난 경우 : `400`
- `SHARE006` : 요청시 필드값이 하나라도 비어있을때 : `400`

