### PR TITLE
 읽은 채팅의 개수 조회(아이콘 표시), 참가한 모든 채팅방의 회원 조회 실패케이스 구현

### DIFF
--- a/src/main/java/louie/hanse/shareplate/service/ChatRoomMemberService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ChatRoomMemberService.java
@@ -37,6 +37,7 @@ public class ChatRoomMemberService {
     }
 
     public List<ChatRoomMemberListResponse> getChatRoomMemberList(Long memberId) {
+        memberService.findByIdOrElseThrow(memberId);
         return chatRoomMemberRepository
             .findAllByMemberId(memberId).stream()
             .map(ChatRoomMemberListResponse::new)

--- a/src/main/java/louie/hanse/shareplate/service/ChatService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ChatService.java
@@ -38,6 +38,7 @@ public class ChatService {
     }
 
     public int getTotalUnread(Long memberId) {
+        memberService.findByIdOrElseThrow(memberId);
         return chatRepository.getTotalUnread(memberId);
     }
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -693,8 +693,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /shares HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDUsImlhdCI6MTY2NTIxMTU0NSwibWVtYmVySWQiOjIzNTU4NDEwMzN9.ZDQovvHnMx97FBhnRO5J3xSe1dlDB18Ct1M46TNQUww
-Content-Type: multipart/form-data; boundary="gGrmApofyFb6Pg3Qix04ogimxbbpX-Dw9QEE"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjAsImlhdCI6MTY2NTIzNTUyMCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.WhiJiYur8-u0dvjPFUshABAs3YxhHKXrWmaqKolY8vY
+Content-Type: multipart/form-data; boundary="UFg3BYnFlwO1uu4bTJwaaybVCUK6XpRaP"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=images; filename=test1.jpg
@@ -875,7 +875,7 @@ Content-Type: application/json
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /shares/mine?mineType=entry&amp;shareType=delivery&amp;isExpired=false HTTP/1.1
 Accept: application/json
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDMsImlhdCI6MTY2NTIxMTU0MywibWVtYmVySWQiOjIzNTU4NDEwNDd9.hkxFJUK1ohKiKCGAIXVPhfOI-T5UFAcQwyxwSWqsQMw</code></pre>
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTgsImlhdCI6MTY2NTIzNTUxOCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.NB51knnUVI1-h-gZ70pPewdasNMoT47Yn3jDGN08Hso</code></pre>
 </div>
 </div>
 </div>
@@ -914,7 +914,7 @@ Content-Type: application/json
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /shares/mine?mineType=writer&amp;shareType=delivery&amp;isExpired=false HTTP/1.1
 Accept: application/json
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDMsImlhdCI6MTY2NTIxMTU0MywibWVtYmVySWQiOjIzNzA4NDI5OTd9.9TUzR7u327gZkP7aGtNoEOZmv2XGy5sADQrFlWDeXu4</code></pre>
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTksImlhdCI6MTY2NTIzNTUxOSwibWVtYmVySWQiOjIzNzA4NDI5OTd9.zpPRDewaUhNdBAYPf78gISCh0qLFV79X3xUztP9fOqg</code></pre>
 </div>
 </div>
 </div>
@@ -953,7 +953,7 @@ Content-Type: application/json
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /shares/mine?mineType=wish&amp;shareType=ddddddd&amp;isExpired=false HTTP/1.1
 Accept: application/json
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDMsImlhdCI6MTY2NTIxMTU0MywibWVtYmVySWQiOjIzNzA4NDI5OTd9.9TUzR7u327gZkP7aGtNoEOZmv2XGy5sADQrFlWDeXu4</code></pre>
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTksImlhdCI6MTY2NTIzNTUxOSwibWVtYmVySWQiOjIzNzA4NDI5OTd9.zpPRDewaUhNdBAYPf78gISCh0qLFV79X3xUztP9fOqg</code></pre>
 </div>
 </div>
 </div>
@@ -1009,8 +1009,8 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /shares/3 HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDEsImlhdCI6MTY2NTIxMTU0MSwibWVtYmVySWQiOjIzNTU4NDEwMzN9.YC_TO7f9nHqn06mSK8h_b2u1rtZepPYjj6Zvtb1EnAo
-Content-Type: multipart/form-data; boundary="mD6mOeJeWKjbGvRHUqjUE592qlMomDvAzaX8j"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTgsImlhdCI6MTY2NTIzNTUxOCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.0CDeXqKbE9v28p_48SuQL9VQ7lbDfWDIBhQErh3Sycs
+Content-Type: multipart/form-data; boundary="xbFEzSRkXU9xwAsXH_nv6hvZwJ5aC_dX0MkxaNnI"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=images; filename=test1.jpg
@@ -1130,7 +1130,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /shares/1000000000 HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzcsImlhdCI6MTY2NTIxMTUzNywibWVtYmVySWQiOjIzNTU4NDEwMzN9.BvhMUyz1OH9t0oCG8K9FO5j26KLNauqzu5qnLl3KXHE</code></pre>
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTQsImlhdCI6MTY2NTIzNTUxNCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.HfN5HZKUBIlIuhJlioQgghOGJy9FxfjMSWO2XqRjtE4</code></pre>
 </div>
 </div>
 </div>
@@ -1162,7 +1162,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /shares/4 HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzcsImlhdCI6MTY2NTIxMTUzNywibWVtYmVySWQiOjIzNTU4NDEwMzN9.BvhMUyz1OH9t0oCG8K9FO5j26KLNauqzu5qnLl3KXHE</code></pre>
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTQsImlhdCI6MTY2NTIzNTUxNCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.HfN5HZKUBIlIuhJlioQgghOGJy9FxfjMSWO2XqRjtE4</code></pre>
 </div>
 </div>
 </div>
@@ -1184,7 +1184,7 @@ Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4i
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzIsImlhdCI6MTY2NTIxMTUzMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.aD_w2s7wMzRwdwGBAxMYFEGFUP8wckqRDr9_6eYmMjc
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTAsImlhdCI6MTY2NTIzNTUxMCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.nSCmOpEC-f3rtGP1tWgxV_9ZCyg6_3orL3Un03Vo9Cg
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1214,8 +1214,8 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /members HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzIsImlhdCI6MTY2NTIxMTUzMiwibWVtYmVySWQiOjIzNTU4NDEwMzN9.vB7057tQ8jN1zkRrfBDij9tHjNd_4K7qZ36B1uDSgVk
-Content-Type: multipart/form-data; boundary="jSpMbTkg7RaTn8YSbpcZB5BUO5tzM4zCw"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTAsImlhdCI6MTY2NTIzNTUxMCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.0hIw3DaP2oY5OhRtpUTWFd33OM4jNdAOW7ZDiV990dI
+Content-Type: multipart/form-data; boundary="B51dnMpv2UlkNWp0uS-0kKmBaz6zhzgJxLbdB7Wi"; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=profileImage; filename=수정된 test1.txt
@@ -1255,7 +1255,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /shares/3/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjUsImlhdCI6MTY2NTIxMTUyNSwibWVtYmVySWQiOjIzNTU4NDEwMzN9.nho37NnOhriMekTDWBldHrFvSOM2MSdJKnBABp0PFbw
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDQsImlhdCI6MTY2NTIzNTUwNCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.4bsIuq4qZhwBspsg03Xd4srSUbznenKuXD3Z9Qsiy3I
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1278,7 +1278,7 @@ Content-Type: application/json</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /shares/2222/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjMsImlhdCI6MTY2NTIxMTUyMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.8bw7uYD3xC3q-39P5-gunizBo-IPcD0y8TYS1mx07aI
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDMsImlhdCI6MTY2NTIzNTUwMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.RLQYwsLw_opH39mu4anlgOJzGwNHkFz0Uhu6RaEFbCY
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1307,7 +1307,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /shares/1/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjUsImlhdCI6MTY2NTIxMTUyNSwibWVtYmVySWQiOjIzNTU4NDEwNDd9.ccZtPc5CiQGrzmxx0QX18WTnwvVX5Yh7rBtFbCL4PPg
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDQsImlhdCI6MTY2NTIzNTUwNCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.x9HJzA9hUgdtUkra8J3FDZzP8IS_UK-dfWRHvBcIOQM
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1336,7 +1336,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /shares/1/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjMsImlhdCI6MTY2NTIxMTUyMywibWVtYmVySWQiOjIzNTU4NDEwMzN9.z2vunGS3z_0hy_q_6L-JropIiXlDeKTUzhw1LkmW7Y4
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDMsImlhdCI6MTY2NTIzNTUwMywibWVtYmVySWQiOjIzNTU4NDEwMzN9.ryHuu-LFLpxrXlYzgmtXuztDl8kFl25We53Uzr-zzCo
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1365,7 +1365,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /shares/9/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjUsImlhdCI6MTY2NTIxMTUyNSwibWVtYmVySWQiOjIzNTU4NDEwMzN9.nho37NnOhriMekTDWBldHrFvSOM2MSdJKnBABp0PFbw
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDQsImlhdCI6MTY2NTIzNTUwNCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.4bsIuq4qZhwBspsg03Xd4srSUbznenKuXD3Z9Qsiy3I
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1394,7 +1394,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /shares/2222/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjMsImlhdCI6MTY2NTIxMTUyMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.8bw7uYD3xC3q-39P5-gunizBo-IPcD0y8TYS1mx07aI
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDMsImlhdCI6MTY2NTIzNTUwMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.RLQYwsLw_opH39mu4anlgOJzGwNHkFz0Uhu6RaEFbCY
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1423,7 +1423,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /shares/4/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjMsImlhdCI6MTY2NTIxMTUyMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.8bw7uYD3xC3q-39P5-gunizBo-IPcD0y8TYS1mx07aI
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDIsImlhdCI6MTY2NTIzNTUwMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.g--u60_0QTsw7MYASNHuHQJxvAstF5kRb1-N_Dxnncs
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1452,7 +1452,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /shares/7/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjEsImlhdCI6MTY2NTIxMTUyMSwibWVtYmVySWQiOjIzNTU4NDEwNDd9.sgndF-zcW1QeoiYiZk6NXFak71QdGWdQYngpqP-XqSc
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDEsImlhdCI6MTY2NTIzNTUwMSwibWVtYmVySWQiOjIzNTU4NDEwNDd9.XP4L1ZPRNy9A8c-ikoXFXVlRVwgUuhtxESUTOX0x1mU
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1481,7 +1481,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /shares/8/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjIsImlhdCI6MTY2NTIxMTUyMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.0w-e_SgBUmSc3h6ueb7awvxkQCaooHTWTdBXKtqSPZ0
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDIsImlhdCI6MTY2NTIzNTUwMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.g--u60_0QTsw7MYASNHuHQJxvAstF5kRb1-N_Dxnncs
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1510,7 +1510,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /entries HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjYsImlhdCI6MTY2NTIxMTUyNiwibWVtYmVySWQiOjIzNzA4NDI5OTd9.9U1uaF-gbGa8-6lREn2zmpZTvniBvRD4s1oa5MYVo-c
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDUsImlhdCI6MTY2NTIzNTUwNSwibWVtYmVySWQiOjIzNzA4NDI5OTd9.3cDMpPN9SM-8LTzB_vGsv-2lskwnrT9Ct6edK1-_rBI
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1538,7 +1538,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /shares/8/entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjIsImlhdCI6MTY2NTIxMTUyMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.0w-e_SgBUmSc3h6ueb7awvxkQCaooHTWTdBXKtqSPZ0
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDIsImlhdCI6MTY2NTIzNTUwMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.g--u60_0QTsw7MYASNHuHQJxvAstF5kRb1-N_Dxnncs
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1567,7 +1567,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /wish-list HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDcsImlhdCI6MTY2NTIxMTU0NywibWVtYmVySWQiOjIzNTU4NDEwMzN9.SyMKc_eEsk2PcXvCLwpgggAthpDj3efSnjG2rQKlWF4
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjMsImlhdCI6MTY2NTIzNTUyMywibWVtYmVySWQiOjIzNTU4NDEwMzN9.xlPTOr2j-ebXwzLgS9DX3pdY74AiP9DAhDH-uZMT8ew
 Content-Type: application/json
 
 {
@@ -1594,7 +1594,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /wish-list HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDgsImlhdCI6MTY2NTIxMTU0OCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.9KmgwgG_SC10lm03eXJ41n27c7PNk60c00Ak8OWyFtg
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjQsImlhdCI6MTY2NTIzNTUyNCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.OwQHiyAmjpj3vdZvUuHmOq2Nm6hNG_64COK5l6et_0k
 Content-Type: application/json
 
 {
@@ -1627,7 +1627,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /wish-list HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDcsImlhdCI6MTY2NTIxMTU0NywibWVtYmVySWQiOjIzNTU4NDEwNDd9.6desfIQ8BUjrn5L_xAukaqQVXluVTsjgOlBQKlWeJ3w
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjMsImlhdCI6MTY2NTIzNTUyMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.D8rXa7ixVfsWIY8t0PqdbS9Vsd5kKl52tw48olIqkpw
 Content-Type: application/json
 
 {
@@ -1660,7 +1660,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /wish-list HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDgsImlhdCI6MTY2NTIxMTU0OCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.9KmgwgG_SC10lm03eXJ41n27c7PNk60c00Ak8OWyFtg
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjQsImlhdCI6MTY2NTIzNTUyNCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.OwQHiyAmjpj3vdZvUuHmOq2Nm6hNG_64COK5l6et_0k
 Content-Type: application/json
 
 {
@@ -1693,7 +1693,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /wish-list HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDYsImlhdCI6MTY2NTIxMTU0NiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.sY66zvnio66GrYqddaD4ZD19XFqGKt3qO8fM74ZGX54
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjIsImlhdCI6MTY2NTIzNTUyMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.8B-f4kdczgac0kjUKvBVEwkDcAfwFK75SCxfC-0eaqE
 Content-Type: application/json
 
 {
@@ -1720,7 +1720,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /wish-list HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDcsImlhdCI6MTY2NTIxMTU0NywibWVtYmVySWQiOjIzNTU4NDEwNDd9.6desfIQ8BUjrn5L_xAukaqQVXluVTsjgOlBQKlWeJ3w
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjMsImlhdCI6MTY2NTIzNTUyMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.D8rXa7ixVfsWIY8t0PqdbS9Vsd5kKl52tw48olIqkpw
 Content-Type: application/json
 
 {
@@ -1753,7 +1753,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /wish-list HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxNDcsImlhdCI6MTY2NTIxMTU0NywibWVtYmVySWQiOjIzNTU4NDEwNDd9.6desfIQ8BUjrn5L_xAukaqQVXluVTsjgOlBQKlWeJ3w
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMjIsImlhdCI6MTY2NTIzNTUyMiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.8B-f4kdczgac0kjUKvBVEwkDcAfwFK75SCxfC-0eaqE
 Content-Type: application/json
 
 {
@@ -1786,7 +1786,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /notifications/activity HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzYsImlhdCI6MTY2NTIxMTUzNiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.RA8dGf5M5GffaZaA6yQwT1bFzxMPr3E6xWnga_lQwGk
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTMsImlhdCI6MTY2NTIzNTUxMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.3Uc0pEmZzwStJtAEBzCLyV7WlH6M3g4cedzh3XI6n9Q
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1828,7 +1828,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /notifications/keyword HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzYsImlhdCI6MTY2NTIxMTUzNiwibWVtYmVySWQiOjIzNTU4NDEwNDd9.RA8dGf5M5GffaZaA6yQwT1bFzxMPr3E6xWnga_lQwGk
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTQsImlhdCI6MTY2NTIzNTUxNCwibWVtYmVySWQiOjIzNTU4NDEwNDd9.3xWoNwgwYTHLrpyLe1lnMRrqLhMxG9R5KDTZ4h8nrTM
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1870,7 +1870,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /notifications/5 HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzQsImlhdCI6MTY2NTIxMTUzNCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.8iV2l5pIXmncw_MzjyK65lthJLrf_ObfmUVOeRjN0Vw
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTEsImlhdCI6MTY2NTIzNTUxMSwibWVtYmVySWQiOjIzNTU4NDEwMzN9.9Xt19PGWxJRS9WWKNNo7BSqYDVjgy5g03xLRcxbFZrw
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -1893,11 +1893,11 @@ Content-Type: application/json</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /notifications HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzUsImlhdCI6MTY2NTIxMTUzNSwibWVtYmVySWQiOjIzNTU4NDEwNDd9.l5IQMQ7Knpwjzx0VzwmYeaNIINpHqkcdYOMuZfbnVXI
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDQ3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMTMsImlhdCI6MTY2NTIzNTUxMywibWVtYmVySWQiOjIzNTU4NDEwNDd9.3Uc0pEmZzwStJtAEBzCLyV7WlH6M3g4cedzh3XI6n9Q
 Content-Type: application/json
 
 {
-  "idList" : [ 3, 4 ]
+  "idList" : [ null, 1 ]
 }</code></pre>
 </div>
 </div>
@@ -1906,7 +1906,13 @@ Content-Type: application/json
 <h3 id="_response_34"><a class="link" href="#_response_34">Response</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "errorCode" : "SHARE012",
+  "message" : "PathVariable의 notificationId가 비어있습니다."
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1920,7 +1926,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /logout HTTP/1.1
-Access-Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzAsImlhdCI6MTY2NTIxMTUzMCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.kATk9NAkOnCTN2lwGM7YXopNdfGi0veKROShY_DlyLo
+Access-Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzU1ODQxMDMzIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDgsImlhdCI6MTY2NTIzNTUwOCwibWVtYmVySWQiOjIzNTU4NDEwMzN9.ooijJDwd76biDgYG-2xAOICPVNFPa2q1uUQwBOIfi88
 Refresh-Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJSZWZyZXNoLVRva2VuIiwiYXVkIjoiMjM1NTg0MTAzMyIsImlzcyI6ImxvdWllMXNlIiwiZXhwIjo5OTk5OTk5OTk5OSwiaWF0IjoxNjYxMTMxMTgxLCJtZW1iZXJJZCI6MjM1NTg0MTAzM30.NmdUynRyknjHpQJ0zbvoCNzVjjF4JNSB7Uhnql8cZF0
 Content-Type: application/json</code></pre>
 </div>
@@ -1944,7 +1950,7 @@ Content-Type: application/json</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /login/verification HTTP/1.1
-Access-Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMzEsImlhdCI6MTY2NTIxMTUzMSwibWVtYmVySWQiOjIzNzA4NDI5OTd9.q2IRXHlnLwUPfeXXRUqz2a-5L3y2MOUA9C6fUmYJASQ
+Access-Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDgsImlhdCI6MTY2NTIzNTUwOCwibWVtYmVySWQiOjIzNzA4NDI5OTd9.lRKOvk_ZZtkeQGe3cDA3hmGP4xyGGAaJiN3CIt4V9oE
 Refresh-Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJSZWZyZXNoLVRva2VuIiwiYXVkIjoiMjM3MDg0Mjk5NyIsImlzcyI6ImxvdWllMXNlIiwiZXhwIjo5OTk5OTk5OTk5OSwiaWF0IjoxNjYxMTMxMTgxLCJtZW1iZXJJZCI6MjM3MDg0Mjk5N30.YocTTr79m94e3fkMK3HiGe5U96WtHT4pvognZpeIS8A
 Content-Type: application/json</code></pre>
 </div>
@@ -1968,7 +1974,7 @@ Content-Type: application/json</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chatrooms?type=entry HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMTgsImlhdCI6MTY2NTIxMTUxOCwibWVtYmVySWQiOjIzNzA4NDI5OTd9.K8hUiYtS2eqKN8aXmk--VWoVTSPRRA1dh4TdsGnl2O0
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkwOTksImlhdCI6MTY2NTIzNTQ5OSwibWVtYmVySWQiOjIzNzA4NDI5OTd9.IzQNMOSx-rY5UwsqQ_ho5D0ZdH-7Yvz5ri8vB_-SId0
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -2049,7 +2055,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chatrooms/1 HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMTYsImlhdCI6MTY2NTIxMTUxNiwibWVtYmVySWQiOjIzNzA4NDI5OTd9.bm2TzPfXXewSe7eABdOANYUBTk0-3fFg9NM9IeAMyFA
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkwOTcsImlhdCI6MTY2NTIzNTQ5NywibWVtYmVySWQiOjIzNzA4NDI5OTd9.1qiJCoIg9ZFUG6eeKh8_7vU8xpZ6wx3YrIIeC73r9Iw
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -2113,7 +2119,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /keywords HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIxIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjgsImlhdCI6MTY2NTIxMTUyOCwibWVtYmVySWQiOjF9.g3JrqI_zHUQAc508SmXc5lDcqjpnbeorrpLiIy49paM
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIxIiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDYsImlhdCI6MTY2NTIzNTUwNiwibWVtYmVySWQiOjF9.7FGuzrAV_JXa_T9f7guhNlWrO9eiaQqckIwck720klA
 Content-Type: application/json
 
 {
@@ -2146,7 +2152,7 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /keywords/location?location=%20 HTTP/1.1
-Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMTUxMjksImlhdCI6MTY2NTIxMTUyOSwibWVtYmVySWQiOjIzNzA4NDI5OTd9.Tzk49p5e9wkJtWR60rbjKWGgfxamw-lZhk12-xwmu9k
+Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3MtVG9rZW4iLCJhdWQiOiIyMzcwODQyOTk3IiwiaXNzIjoibG91aWUxc2UiLCJleHAiOjE2NjUyMzkxMDcsImlhdCI6MTY2NTIzNTUwNywibWVtYmVySWQiOjIzNzA4NDI5OTd9.CdzVz4CYcJZf9iRm_srzTo9kILklrZh8yfljQQ4_tfc
 Content-Type: application/json</code></pre>
 </div>
 </div>
@@ -2171,7 +2177,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-09-23 14:03:04 +0900
+Last updated 2022-09-21 16:49:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/louie/hanse/shareplate/integration/chat/ChatUnreadCountIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/chat/ChatUnreadCountIntegrationTest.java
@@ -1,0 +1,49 @@
+package louie.hanse.shareplate.integration.chat;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import louie.hanse.shareplate.exception.type.MemberExceptionType;
+import louie.hanse.shareplate.integration.InitIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("채팅 안읽은 개수 조회 기능")
+public class ChatUnreadCountIntegrationTest extends InitIntegrationTest {
+
+    @Test
+    void 읽지않은_채팅의_개수를_조회한다() {
+        String accessToken = jwtProvider.createAccessToken(2370842997L);
+
+        given(documentationSpec)
+            .filter(document("chat-unread-count"))
+            .header(AUTHORIZATION, accessToken)
+
+            .when()
+            .get("/chats/unread")
+
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("count", equalTo(5));
+    }
+
+    @Test
+    void 유효하지_않은_회원이_읽지않은_채팅의_개수를_조회한다() {
+        String accessToken = jwtProvider.createAccessToken(1L);
+
+        given(documentationSpec)
+            .filter(document("chat-unread-count"))
+            .header(AUTHORIZATION, accessToken)
+
+            .when()
+            .get("/chats/unread")
+
+            .then()
+            .statusCode(MemberExceptionType.MEMBER_NOT_FOUND.getStatusCode().value())
+            .body("errorCode", equalTo(MemberExceptionType.MEMBER_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(MemberExceptionType.MEMBER_NOT_FOUND.getMessage()));
+    }
+}

--- a/src/test/java/louie/hanse/shareplate/integration/chatRoomMember/ChatRoomMemberSearchIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/chatRoomMember/ChatRoomMemberSearchIntegrationTest.java
@@ -1,10 +1,12 @@
 package louie.hanse.shareplate.integration.chatRoomMember;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import louie.hanse.shareplate.exception.type.MemberExceptionType;
 import louie.hanse.shareplate.integration.InitIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,5 +29,22 @@ class ChatRoomMemberSearchIntegrationTest extends InitIntegrationTest {
             .then()
             .statusCode(HttpStatus.OK.value())
             .body("", hasSize(5));
+    }
+
+    @Test
+    void 유효하지_않은_회원이_참가한_모든_채팅방에_대한_회원_정보를_조회한다() {
+        String accessToken = jwtProvider.createAccessToken(1L);
+
+        given(documentationSpec)
+            .filter(document("chatRoomMember-list-get"))
+            .header(AUTHORIZATION, accessToken)
+
+            .when()
+            .get("/chatroom-members")
+
+            .then()
+            .statusCode(MemberExceptionType.MEMBER_NOT_FOUND.getStatusCode().value())
+            .body("errorCode", equalTo(MemberExceptionType.MEMBER_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(MemberExceptionType.MEMBER_NOT_FOUND.getMessage()));
     }
 }

--- a/src/test/java/louie/hanse/shareplate/integration/notification/NotificationDeleteSelectionIntegrationTest.java
+++ b/src/test/java/louie/hanse/shareplate/integration/notification/NotificationDeleteSelectionIntegrationTest.java
@@ -65,6 +65,9 @@ class NotificationDeleteSelectionIntegrationTest extends InitIntegrationTest {
             .header(AUTHORIZATION, accessToken)
             .body(requestBody)
 
+            .when()
+            .delete("/notifications")
+
             .then()
             .statusCode(NotificationExceptionType.PATH_VARIABLE_EMPTY_NOTIFICATION_ID.getStatusCode().value())
             .body("errorCode",


### PR DESCRIPTION
## 📃 Description
### 안 읽은 채팅의 개수 조회(아이콘 표시)
- `AUTH005` : 요청 시 보낸 `AccessToken` 의 값이 비어있을 때(null 또는 빈 문자열) : `400`
- `AUTH006` : `AccessToken`이 만료되었을 때 : `401`
- `AUTH008` : `AccessToken`이 변조되었을 때 : `401`
- `MEMBER001` :  `AccessToken`의 memberId에 대한 회원이 존재하지 않을 때 : `400`

### 참가한 모든 채팅방에 대한 회원 조회
- `AUTH005` : 요청 시 보낸 `AccessToken` 의 값이 비어있을 때(null 또는 빈 문자열) : `400`
- `AUTH006` : `AccessToken`이 만료되었을 때 : `401`
- `AUTH008` : `AccessToken`이 변조되었을 때 : `401`
- `MEMBER001` :  `AccessToken`의 memberId에 대한 회원이 존재하지 않을 때 : `400`
## ☑ Todo
