### PR TITLE
쉐어 참여 취소 API 누락된 실패 케이스와 채팅방까지 나가기 구현

### DIFF
--- a/src/main/java/louie/hanse/shareplate/exception/type/EntryExceptionType.java
+++ b/src/main/java/louie/hanse/shareplate/exception/type/EntryExceptionType.java
@@ -10,7 +10,8 @@ public enum EntryExceptionType implements ExceptionType {
     SHARE_OVERCAPACITY("ENTRY003", "모집정원이 초과된 쉐어입니다.", BAD_REQUEST),
     CLOSE_TO_THE_CLOSED_DATE_TIME("ENTRY004", "모집시간 1시간 미만으로 남은 경우, 참가 취소를 할 수 없습니다.", BAD_REQUEST),
     CLOSED_DATE_TIME_HAS_PASSED_NOT_CANCEL("ENTRY005", "모집이 지난 쉐어는 참가 취소 할 수 없습니다.", BAD_REQUEST),
-    CLOSED_DATE_TIME_HAS_PASSED_NOT_JOIN("ENTRY006", "모집이 지난 쉐어는 참가 할 수 없습니다.", BAD_REQUEST);
+    CLOSED_DATE_TIME_HAS_PASSED_NOT_JOIN("ENTRY006", "모집이 지난 쉐어는 참가 할 수 없습니다.", BAD_REQUEST),
+    SHARE_WRITER_CANNOT_ENTRY_CANCEL("ENTRY007", "쉐어 작성자는 참여 취소를 할 수 없습니다.", BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/louie/hanse/shareplate/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/louie/hanse/shareplate/repository/ChatRoomMemberRepository.java
@@ -40,4 +40,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
         @Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
 
     boolean existsByMemberIdAndChatRoomId(Long memberId, Long chatRoomId);
+
+    void deleteByMemberIdAndChatRoomId(Long memberId, Long chatRoomId);
 }

--- a/src/main/java/louie/hanse/shareplate/service/EntryService.java
+++ b/src/main/java/louie/hanse/shareplate/service/EntryService.java
@@ -68,6 +68,8 @@ public class EntryService {
             throw new GlobalException(EntryExceptionType.SHARE_WRITER_CANNOT_ENTRY_CANCEL);
         }
         entryRepository.deleteByMemberIdAndShareId(memberId, shareId);
+        chatRoomMemberRepository.deleteByMemberIdAndChatRoomId(
+            memberId, share.getEntryChatRoom().getId());
     }
 
     public List<Long> getIdList(Long memberId) {

--- a/src/main/java/louie/hanse/shareplate/service/EntryService.java
+++ b/src/main/java/louie/hanse/shareplate/service/EntryService.java
@@ -51,8 +51,8 @@ public class EntryService {
 
     @Transactional
     public void cancel(Long shareId, Long memberId) {
-        memberService.findByIdOrElseThrow(memberId);
-        Share share = shareService.findByIdOrElseThrow(shareId);
+        Member member = memberService.findByIdOrElseThrow(memberId);
+        Share share = shareService.findWithWriterByIdOrElseThrow(shareId);
 
         share.isCanceledThrowException();
         if (!isExistEntry(shareId, memberId)) {
@@ -63,6 +63,9 @@ public class EntryService {
         }
         if (share.isLeftLessThanAnHour()) {
             throw new GlobalException(EntryExceptionType.CLOSE_TO_THE_CLOSED_DATE_TIME);
+        }
+        if (share.isWriter(member)) {
+            throw new GlobalException(EntryExceptionType.SHARE_WRITER_CANNOT_ENTRY_CANCEL);
         }
         entryRepository.deleteByMemberIdAndShareId(memberId, shareId);
     }

--- a/src/main/java/louie/hanse/shareplate/service/ShareService.java
+++ b/src/main/java/louie/hanse/shareplate/service/ShareService.java
@@ -183,7 +183,7 @@ public class ShareService {
             .orElseThrow(() -> new GlobalException(ShareExceptionType.SHARE_NOT_FOUND));
     }
 
-    private Share findWithWriterByIdOrElseThrow(Long id) {
+    public Share findWithWriterByIdOrElseThrow(Long id) {
         return shareRepository.findWithWriterById(id)
             .orElseThrow(() -> new GlobalException(ShareExceptionType.SHARE_NOT_FOUND));
     }


### PR DESCRIPTION
## ☑ Todo
- [x] 쉐어 작성자가 쉐어 참여 취소 시 예외 메세지를 반환한다.
- [x] 쉐어 참여 취소 시 채팅방도 함께 나가져야 한다.